### PR TITLE
chore: Use the `which` crate to determine if zathura is installed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,6 +1354,7 @@ dependencies = [
  "predicates",
  "ratatui",
  "reqwest",
+ "which",
 ]
 
 [[package]]
@@ -3100,6 +3101,15 @@ dependencies = [
  "lazy_static",
  "serde",
  "wezterm-dynamic",
+]
+
+[[package]]
+name = "which"
+version = "8.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ crossterm = "0.29.0"
 nix = { version = "0.31.3", features = ["user", "process"] }
 ratatui = "0.30.2"
 reqwest = { version = "0.13.4", features = ["blocking"] }
+which = "8.0.5"
 
 [dev-dependencies]
 assert_cmd = "2.0.0"

--- a/src/open.rs
+++ b/src/open.rs
@@ -13,7 +13,7 @@ pub fn open_pdf_man_page(path: &Path) -> io::Result<()> {
         .output()
         .is_ok_and(|output| !output.stdout.is_empty())
     {
-        "xdg-open".into()
+        "xdg-open".to_string()
     } else if which("zathura").is_ok() {
         "zathura".to_string()
     } else {

--- a/src/open.rs
+++ b/src/open.rs
@@ -3,6 +3,7 @@
 use std::io::{self, Error};
 use std::path::Path;
 use std::process::{Command, Stdio};
+use which::which;
 
 // Get PDF reader, then open PDF man page
 pub fn open_pdf_man_page(path: &Path) -> io::Result<()> {
@@ -13,13 +14,7 @@ pub fn open_pdf_man_page(path: &Path) -> io::Result<()> {
         .is_ok_and(|output| !output.stdout.is_empty())
     {
         "xdg-open".into()
-    } else if Command::new("zathura")
-        .arg("--version")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .is_ok_and(|status| status.success())
-    {
+    } else if which("zathura").is_ok() {
         "zathura".to_string()
     } else {
         return Err(Error::other(


### PR DESCRIPTION
### Description

Use a cleaner and more idiomatic way to determine if `zathura` is installed by relying on the `which` crate (rather then invoking it unconditionally).