### PR TITLE
chore(i18n): Refine zathura detection

### DIFF
--- a/src/open.rs
+++ b/src/open.rs
@@ -1,7 +1,7 @@
 //! Open man page in PDF reader
 
 use std::io::{self, Error};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use which::which;
 
@@ -13,13 +13,11 @@ pub fn open_pdf_man_page(path: &Path) -> io::Result<()> {
         .output()
         .is_ok_and(|output| !output.stdout.is_empty())
     {
-        "xdg-open".to_string()
-    } else if which("zathura").is_ok() {
-        "zathura".to_string()
+        PathBuf::from("xdg-open")
     } else {
-        return Err(Error::other(
-            "No PDF reader defined in XDG Mime Application and zathura (fallback option) isn't installed",
-        ));
+        which("zathura").map_err(|_| {
+            Error::other("No PDF reader defined in XDG Mime Application and zathura (fallback option) isn't installed")
+        })?
     };
 
     // Open the man page in PDF reader


### PR DESCRIPTION
### Description

The `which` crate returns a `PathBuf`, which we can directly reuse in the `Command::new` call later (avoiding the need to convert it to string beforehand).
We therefore have to declare "xdg-open" as a `PathBuf` as well, otherwise there would be a type mismatch.

Aside from being slightly cleaner and more idiomatic, this also allows to simplifies the logic as a side benefit (avoids the needs of an extra `else if` branch).